### PR TITLE
Fix package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,8 +51,9 @@ extension SwiftSetting {
 
 for target in package.targets where target.isLocal {
   var swiftSettings = target.swiftSettings ?? []
-  swiftSettings.append(.enableActorDataRaceChecks(.whenDebug))
-  swiftSettings.append(.debugTime(.whenDebug))
+  // NB: Uncomment to enable unsafe-flags for development:
+  //swiftSettings.append(.enableActorDataRaceChecks(.whenDebug))
+  //swiftSettings.append(.debugTime(.whenDebug))
 #if !hasFeature(StrictConcurrency)
   swiftSettings.append(.enableUpcomingFeature("StrictConcurrency", .whenDebug))
   swiftSettings.append(.enableExperimentalFeature("StrictConcurrency", .whenDebug))

--- a/Package.swift
+++ b/Package.swift
@@ -55,14 +55,14 @@ for target in package.targets where target.isLocal {
   //swiftSettings.append(.enableActorDataRaceChecks(.whenDebug))
   //swiftSettings.append(.debugTime(.whenDebug))
 #if !hasFeature(StrictConcurrency)
-  swiftSettings.append(.enableUpcomingFeature("StrictConcurrency", .whenDebug))
-  swiftSettings.append(.enableExperimentalFeature("StrictConcurrency", .whenDebug))
+  swiftSettings.append(.enableUpcomingFeature("StrictConcurrency"))
+  swiftSettings.append(.enableExperimentalFeature("StrictConcurrency"))
 #endif
 #if !hasFeature(GlobalConcurrency)
-  swiftSettings.append(.enableUpcomingFeature("GlobalConcurrency", .whenDebug))
+  swiftSettings.append(.enableUpcomingFeature("GlobalConcurrency"))
 #endif
 #if !hasFeature(InternalImportsByDefault)
-  swiftSettings.append(.enableUpcomingFeature("InternalImportsByDefault", .whenDebug))
+  swiftSettings.append(.enableUpcomingFeature("InternalImportsByDefault"))
 #endif
   target.swiftSettings = swiftSettings
 }


### PR DESCRIPTION
## Summary

This PR fixes some issues with Swift Package manifest.

## What was done

- [x] Disable unsafe flags from swift settings, to address issues with package integration. 
- [x] Enable upcoming/experimental swift compiler flags for release builds.
